### PR TITLE
Add option to use ImageMagick instead of GraphicsMagick

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Converts the provided image in ASCII art.
  - `size` (Object): The size of the result image (ASCII art):
     - `height` (Number|String): The height value (default: `"100%"`).
     - `width` (Number|String): The width value (default: computed value to keep aspect ratio).
+ - `imageMagick` (Boolean): If `true`, ImageMagick will be used instead of `GraphicsMagick` (default: `false`).
 - **Function** `callback`: The callback function.
 
 ## How to contribute

--- a/lib/index.js
+++ b/lib/index.js
@@ -41,6 +41,11 @@ var ImageToAscii = module.exports = function (options, callback) {
     self.options = options = Util.mergeRecursive(ImageToAscii.defaults, options);
     callback = callback || function () {};
 
+    // Use ImageMagick instead of GraphicsMagick
+    if (options.imageMagick) {
+      Gm = require('gm').subClass({imageMagick: true});
+    }
+
     // Convert pixels to array
     if (typeof options.pixels === "string") {
         options.pixels = options.pixels.split("");
@@ -152,4 +157,5 @@ ImageToAscii.defaults = {
   , size: {
         height: "100%"
     }
+  , imageMagick: false
 };


### PR DESCRIPTION
This PR adds a new option `imageMagick` (Boolean) which configures `gm` to use ImageMagick instead of GraphicsMagic. No new features, just this one option.