### PR TITLE
Include Buffer source option

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Converts the provided image in ASCII art.
 
 #### Params
 
-- **String** `source`: The path/url to the image.
+- **String|Buffer** `source`: The path/url to the image or a `Buffer` object.
 - **Object|String** `options`: The path to the image or an object containing the following fields:
 
  **Size Options**:

--- a/lib/index.js
+++ b/lib/index.js
@@ -29,7 +29,7 @@ const DEFAULTS = {
  *
  * @name imageToAscii
  * @function
- * @param {String} source The path/url to the image.
+ * @param {String|Buffer} source The path/url to the image or a Buffer object.
  * @param {Object|String} options The path to the image or an object containing
  * the following fields:
  *


### PR DESCRIPTION
In accordance with documentation of [`image-parser`](https://github.com/IonicaBizau/image-parser#params)

Addresses side discussion in #57.