### PR TITLE
Fix whitespace errors

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -61,4 +61,3 @@ Converts the provided image in ASCII art.
     the `options` in the arguments. Use this option to implement your own
     stringifier.
 - **Function** `callback`: The callback function.
-

--- a/example/webcam.sh
+++ b/example/webcam.sh
@@ -1,11 +1,11 @@
 while true; do
-    {	
-    	# try block
-    	streamer -f jpeg -o out.jpeg -q
+    {
+        # try block
+        streamer -f jpeg -o out.jpeg -q
     } || {
-    	# catch block
-    	echo "[Error: failed to open video camera!]"
-    	exit 1
+        # catch block
+        echo "[Error: failed to open video camera!]"
+        exit 1
     }
 
     node webcam.js


### PR DESCRIPTION
Two files in the repo contained a few minor whitespace errors:

```
DOCUMENTATION.md:64: new blank line at EOF.
example/webcam.sh:2: trailing whitespace.
+    {
example/webcam.sh:3: space before tab in indent.
+       # try block
example/webcam.sh:4: space before tab in indent.
+       streamer -f jpeg -o out.jpeg -q
example/webcam.sh:6: space before tab in indent.
+       # catch block
example/webcam.sh:7: space before tab in indent.
+       echo "[Error: failed to open video camera!]"
example/webcam.sh:8: space before tab in indent.
+       exit 1
```

This fixes it. Thanks for this project!